### PR TITLE
Add cbl/blade-script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The TALL stack is a full stack development solution featuring some of the librar
 
 - [Alptail](https://www.alptail.com) - A collection of open-source UI components, using Tailwind.css and Alpine.js.
 - [Blade Icons](https://github.com/blade-ui-kit/blade-icons) - A package to easily make use of SVG icons in your Laravel Blade views.
+- [Blade Script](https://github.com/cbl/blade-script) - A package to easily add transpiled & minified scripts to your blade components.
 - [Laravel Form Components](https://github.com/pascalbaljetmedia/laravel-form-components) - A set of Blade components to rapidly build forms with Tailwind CSS Custom Forms and Bootstrap 4.
 - [Laravel TALL Preset](https://github.com/laravel-frontend-presets/tall) - A front-end preset for Laravel to scaffold an application using the TALL stack.
 - [Tailwind UI](https://tailwindui.com) - Beautiful UI components built with Tailwind CSS. Offers Alpine.js integration.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The TALL stack is a full stack development solution featuring some of the librar
 
 - [Alptail](https://www.alptail.com) - A collection of open-source UI components, using Tailwind.css and Alpine.js.
 - [Blade Icons](https://github.com/blade-ui-kit/blade-icons) - A package to easily make use of SVG icons in your Laravel Blade views.
-- [Blade Script](https://github.com/cbl/blade-script) - A package to easily add transpiled & minified scripts to your blade components.
+- [Blade Script](https://github.com/cbl/blade-script) - A package to easily add transpiled & minified scripts to your Blade components.
 - [Laravel Form Components](https://github.com/pascalbaljetmedia/laravel-form-components) - A set of Blade components to rapidly build forms with Tailwind CSS Custom Forms and Bootstrap 4.
 - [Laravel TALL Preset](https://github.com/laravel-frontend-presets/tall) - A front-end preset for Laravel to scaffold an application using the TALL stack.
 - [Tailwind UI](https://tailwindui.com) - Beautiful UI components built with Tailwind CSS. Offers Alpine.js integration.


### PR DESCRIPTION
Adding a package to transpile and minify javascript code that are written in the `x-style` tag.

> In case you want to add javascript functionality to a blade component, you can write it directly in the script tag. However, > the script will then not be minified and if a component is used multiple times, the script tag will also be included multiple > times.
>
> Blade Script solves these problems. The javascript code can be minified in production and each script tag is only included > once all without running a compiler separately. Also only required scripts are included.

