### PR TITLE
Add TALL stack preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The TALL stack is a full stack development solution featuring some of the librar
 - [Blade Script](https://github.com/cbl/blade-script) - A package to easily add transpiled & minified scripts to your Blade components.
 - [Laravel Form Components](https://github.com/pascalbaljetmedia/laravel-form-components) - A set of Blade components to rapidly build forms with Tailwind CSS Custom Forms and Bootstrap 4.
 - [Laravel TALL Preset](https://github.com/laravel-frontend-presets/tall) - A front-end preset for Laravel to scaffold an application using the TALL stack.
+- [Laravel TALL Preset](https://github.com/use-preset/laravel-tall/) - A preset for installing the TALL stack with just one command.
 - [Tailwind UI](https://tailwindui.com) - Beautiful UI components built with Tailwind CSS. Offers Alpine.js integration.
 - [TALL Forms](https://github.com/tanthammar/tall-forms) - A dynamic, responsive Laravel Livewire form component with realtime validation, file uploads, array fields, blade form input components and more.
 


### PR DESCRIPTION
There's the official front-end preset already, but I've recently made a tool dedicated to presets. This is the TALL preset for this tool, which can be installed with just one command. 

Note that the content of the preset is mostly the same as the front-end one.

```bash
npx use-preset laravel-tall
```