### PR TITLE
Added aw-studio/docdress

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The TALL stack is a full stack development solution featuring some of the librar
 - [Blade Icons](https://github.com/blade-ui-kit/blade-icons) - A package to easily make use of SVG icons in your Laravel Blade views.
 - [Blade Script](https://github.com/cbl/blade-script) - A package to easily add transpiled & minified scripts to your Blade components.
 - [Blade Style](https://github.com/cbl/blade-style) - A package to easily minify styles and make use of sass, less, etc. in your Blade components.
+- [Docdress](https://github.com/aw-studio/docdress) - A package to create markdown documentations from GitHub repositories in a Laravel-like design.
 - [Laravel Form Components](https://github.com/pascalbaljetmedia/laravel-form-components) - A set of Blade components to rapidly build forms with Tailwind CSS Custom Forms and Bootstrap 4.
 - [Laravel TALL Preset](https://github.com/laravel-frontend-presets/tall) - A front-end preset for Laravel to scaffold an application using the TALL stack.
 - [Laravel TALL Preset](https://github.com/use-preset/laravel-tall/) - A preset for installing the TALL stack with just one command.


### PR DESCRIPTION
A package to deploy markdown documentations from GitHub repositories in your Laravel project.

<img width="1420" alt="Bildschirmfoto 2020-08-19 um 14 10 54" src="https://user-images.githubusercontent.com/29352871/90653430-73182280-e23f-11ea-8f04-9909f0d11638.png">

Build with Laravel and Tailwind CSS